### PR TITLE
Add SVSM mode

### DIFF
--- a/sevsnpmeasure/cli.py
+++ b/sevsnpmeasure/cli.py
@@ -70,6 +70,7 @@ def main() -> int:
                         help='Kernel command line to calculate hash from (use with --kernel)')
     parser.add_argument('--output-format', choices=['hex', 'base64'], help='Measurement output format', default='hex')
     parser.add_argument('--snp-ovmf-hash', metavar='HASH', help='Precalculated hash of the OVMF binary (hex string)')
+    parser.add_argument('--dump-vmsa', action='store_true', help='Write measured VMSAs to vmsa<N>.bin (SNP mode only)')
     args = parser.parse_args()
 
     if args.mode == 'snp:ovmf-hash':
@@ -94,9 +95,13 @@ def main() -> int:
 
     try:
         sev_mode = SevMode.from_str(args.mode)
+
+        if args.dump_vmsa is True and sev_mode is not SevMode.SEV_SNP:
+            parser.error("--dump-vmsa in only available in SNP mode")
+
         ld = guest.calc_launch_digest(sev_mode, args.vcpus, vcpu_sig, args.ovmf,
-                                      args.kernel, args.initrd, args.append, args.snp_ovmf_hash,
-                                      vmm_type=vmm_type)
+                                  args.kernel, args.initrd, args.append, args.snp_ovmf_hash,
+                                  vmm_type, args.dump_vmsa)
 
         print_measurement(ld, sev_mode, args.output_format, args.verbose)
     except RuntimeError as e:

--- a/sevsnpmeasure/cli.py
+++ b/sevsnpmeasure/cli.py
@@ -49,7 +49,7 @@ def main() -> int:
                                      description='Calculate AMD SEV/SEV-ES/SEV-SNP guest launch measurement')
     parser.add_argument('--version', action='version', version=f'%(prog)s {VERSION}')
     parser.add_argument('-v', '--verbose', action='store_true')
-    parser.add_argument('--mode', choices=['sev', 'seves', 'snp', 'snp:ovmf-hash'], help='Guest mode', required=True)
+    parser.add_argument('--mode', choices=['sev', 'seves', 'snp', 'snp:ovmf-hash', 'snp+svsm'], help='Guest mode', required=True)
     parser.add_argument('--vcpus', metavar='N', type=int, help='Number of guest vcpus', default=None)
     parser.add_argument('--vcpu-type', metavar='CPUTYPE', choices=list(vcpu_types.CPU_SIGS.keys()),
                         help=f"Type of guest vcpu ({', '.join(vcpu_types.CPU_SIGS.keys())})",
@@ -71,6 +71,8 @@ def main() -> int:
     parser.add_argument('--output-format', choices=['hex', 'base64'], help='Measurement output format', default='hex')
     parser.add_argument('--snp-ovmf-hash', metavar='HASH', help='Precalculated hash of the OVMF binary (hex string)')
     parser.add_argument('--dump-vmsa', action='store_true', help='Write measured VMSAs to vmsa<N>.bin (SNP mode only)')
+    parser.add_argument('--vars-size', type=int, help='OVMF_VARS size in bytes (SVSM mode only)')
+    parser.add_argument('--svsm', type=str, help='SVSM binary. (SVSM mode only.)')
     args = parser.parse_args()
 
     if args.mode == 'snp:ovmf-hash':
@@ -96,12 +98,12 @@ def main() -> int:
     try:
         sev_mode = SevMode.from_str(args.mode)
 
-        if args.dump_vmsa is True and sev_mode is not SevMode.SEV_SNP:
+        if args.dump_vmsa is True and not sev_mode in [SevMode.SEV_SNP, SevMode.SEV_SNP_SVSM]:
             parser.error("--dump-vmsa in only available in SNP mode")
 
         ld = guest.calc_launch_digest(sev_mode, args.vcpus, vcpu_sig, args.ovmf,
                                   args.kernel, args.initrd, args.append, args.snp_ovmf_hash,
-                                  vmm_type, args.dump_vmsa)
+                                  vmm_type, args.dump_vmsa, svsm_file=args.svsm, ovmf_vars_size=args.vars_size)
 
         print_measurement(ld, sev_mode, args.output_format, args.verbose)
     except RuntimeError as e:

--- a/sevsnpmeasure/ovmf.py
+++ b/sevsnpmeasure/ovmf.py
@@ -142,3 +142,14 @@ class OVMF(object):
             offset = i * ctypes.sizeof(OvmfSevMetadataSectionDesc)
             item = OvmfSevMetadataSectionDesc.from_buffer_copy(items, offset)
             self._metadata_items.append(item)
+
+class SVSM(OVMF):
+    SVSM_INFO_GUID = "a789a612-0597-4c4b-a49f-cbb1fe9d1ddd"
+
+    def sev_es_reset_eip(self) -> int:
+        # See https://github.com/coconut-svsm/qemu/blob/0e64fb84eeeb86e2b263068c098a64d2f3d5a661/target/i386/sev.c#L2175
+
+        if self.SVSM_INFO_GUID not in self._table:
+            raise RuntimeError("Can't find SVSM_INFO_GUID entry in SVSM table")
+        entry = self._table[self.SVSM_INFO_GUID]
+        return int.from_bytes(entry[:4], byteorder='little') + self.gpa()

--- a/sevsnpmeasure/sev_mode.py
+++ b/sevsnpmeasure/sev_mode.py
@@ -10,6 +10,7 @@ class SevMode(enum.Enum):
     SEV = enum.auto()
     SEV_ES = enum.auto()
     SEV_SNP = enum.auto()
+    SEV_SNP_SVSM = enum.auto()
 
     @staticmethod
     def from_str(s: str):
@@ -19,5 +20,7 @@ class SevMode(enum.Enum):
             return SevMode.SEV_ES
         elif s == "snp" or s == "sev-snp" or s == "SNP" or s == "SEV-SNP":
             return SevMode.SEV_SNP
+        elif s.lower() == "snp+svsm" or s == "sev-snp+svsm":
+            return SevMode.SEV_SNP_SVSM
         else:
             raise ValueError("illegal SEV mode")

--- a/sevsnpmeasure/vmsa.py
+++ b/sevsnpmeasure/vmsa.py
@@ -201,3 +201,52 @@ class VMSA(object):
                 yield bytes(self.bsp_save_area)
             else:
                 yield bytes(self.ap_save_area)
+
+
+class VMSA_SVSM(object):
+    BSP_EIP = 0xfffffff0
+
+    @staticmethod
+    def build_save_area(eip: int, sev_features: int, vcpu_sig: int, vmm_type: VMMType = VMMType.QEMU):
+        return SevEsSaveArea(
+            es = VmcbSeg(16, 0xc93, 0xffffffff, 0),
+            cs = VmcbSeg( 8, 0xc9b, 0xffffffff, 0),
+            ss = VmcbSeg(16, 0xc93, 0xffffffff, 0),
+            ds = VmcbSeg(16, 0xc93, 0xffffffff, 0),
+            fs = VmcbSeg(16, 0xc93, 0xffffffff, 0),
+            gs = VmcbSeg( 0, 0x093, 0xffff, 0),
+            gdtr=VmcbSeg( 0,     0, 0xffff, 0),
+            idtr=VmcbSeg( 0,     0, 0xffff, 0),
+            ldtr=VmcbSeg( 0,  0x82, 0xffff, 0),
+            tr = VmcbSeg( 0,  0x8b, 0xffff, 0),
+            efer=0x1000,
+            cr4=0x40,
+            cr0=0x11,
+            dr7=0x400,
+            dr6=0xffff0ff0,
+            rflags=0x2,
+            rip=eip,
+            g_pat=0x7040600070406,  # PAT MSR: See AMD APM Vol 2, Section A.3
+            rdx=vcpu_sig,
+            sev_features=sev_features,
+            xcr0=0x1,
+        )
+
+    def __init__(self, ap_eip: int, vcpu_sig: int, vmm_type: VMMType = VMMType.QEMU):
+        sev_features = 0x1
+
+        # only one type of vmsa for svsm?
+        self.bsp_save_area = VMSA_SVSM.build_save_area(ap_eip, sev_features, vcpu_sig, vmm_type)
+        if ap_eip:
+            self.ap_save_area = VMSA_SVSM.build_save_area(ap_eip, sev_features, vcpu_sig, vmm_type)
+
+    def pages(self, vcpus: int) -> Iterator[bytes]:
+        """
+        Generate VMSA pages
+        """
+        # only one type of vmsa for svsm?
+        for i in range(vcpus):
+            if i == 0:
+                yield bytes(self.bsp_save_area)
+            else:
+                yield bytes(self.ap_save_area)


### PR DESCRIPTION
Add an option that calculates the SNP launch measurement for the SNP + Coconut SVSM use-case.

Tested with Coconut SVSM main branch from 2024-01-13 (https://github.com/coconut-svsm/svsm/commit/4f312a3c2457595152dab568431fe52e2e566c87)

This adds a new mode "SNP+SVSM", which requires two additional inputs: The SVSM binary and the size of the OVMF variable store file.

