### PR TITLE
Change default value of --guest-features to 0x1

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ options:
   --append CMDLINE      Kernel command line to calculate hash from (use with --kernel)
   --guest-features VALUE
                         Hex representation of the guest kernel features expected to be included
-                        (defaults to 0x21); see README.md for possible values
+                        (defaults to 0x1); see README.md for possible values
   --output-format {hex,base64}
                         Measurement output format
   --snp-ovmf-hash HASH  Precalculated hash of the OVMF binary (hex string)

--- a/sevsnpmeasure/cli.py
+++ b/sevsnpmeasure/cli.py
@@ -71,9 +71,9 @@ def main() -> int:
     parser.add_argument('--append', metavar='CMDLINE',
                         help='Kernel command line to calculate hash from (use with --kernel)')
     parser.add_argument('--guest-features', metavar='VALUE', type=lambda x: int(x, 0),
-                        default=0x21,
+                        default=0x1,
                         help="Hex representation of the guest kernel features expected to be included "
-                             "(defaults to 0x21); see README.md for possible values"),
+                             "(defaults to 0x1); see README.md for possible values"),
     parser.add_argument('--output-format', choices=['hex', 'base64'], help='Measurement output format', default='hex')
     parser.add_argument('--snp-ovmf-hash', metavar='HASH', help='Precalculated hash of the OVMF binary (hex string)')
     parser.add_argument('--dump-vmsa', action='store_true',


### PR DESCRIPTION
Due to a [discussion happening in the linux kernel mailing list](https://lore.kernel.org/kvm/20240314024952.w6n6ol5hjzqayn2g@amd.com/T/), it is expected that the default guest features should no longer include `DEBUG_SWAP` by default. This changes the default value back to `0x1` to comply with those changes.

Resolves #43