### PR TITLE
remove obsolete types-cryptography dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,1 @@
 cryptography==42.0.4
-types-cryptography

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,7 +23,6 @@ packages = sevsnpmeasure
 python_requires = >=3.7
 install_requires =
     cryptography>=39.0.1
-    types-cryptography
 
 [options.entry_points]
 console_scripts =


### PR DESCRIPTION
`types-cryptography` is [deprecated / has become obsolete](https://pypi.org/project/types-cryptography/), as `cryptography` itself now provides type annotations. This removes the `types-cryptography` dependency.