### PR TITLE
Add support for GCE measurement derivation

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ options:
   --vcpu-model MODEL    Guest vcpu model
   --vcpu-stepping STEPPING
                         Guest vcpu stepping
-  --vmm-type VMMTYPE    Type of guest vmm (QEMU, ec2)
+  --vmm-type VMMTYPE    Type of guest vmm (QEMU, ec2, gce)
   --ovmf PATH           OVMF file to calculate hash from
   --kernel PATH         Kernel file to calculate hash from
   --initrd PATH         Initrd file to calculate hash from (use with --kernel)

--- a/sevsnpmeasure/gctx.py
+++ b/sevsnpmeasure/gctx.py
@@ -81,8 +81,12 @@ class GCTX(object):
             self._update(0x03, gpa + offset, ZEROS)
             offset += 4096
 
-    def update_unmeasured_page(self, gpa):
-        self._update(0x04, gpa, ZEROS)
+    def update_unmeasured_pages(self, gpa, length_bytes):
+        assert length_bytes % 4096 == 0
+        offset = 0
+        while offset < length_bytes:
+            self._update(0x04, gpa + offset, ZEROS)
+            offset += 4096
 
     def update_secrets_page(self, gpa):
         self._update(0x05, gpa, ZEROS)

--- a/sevsnpmeasure/guest.py
+++ b/sevsnpmeasure/guest.py
@@ -54,7 +54,10 @@ def snp_update_kernel_hashes(gctx: GCTX, ovmf: OVMF, sev_hashes: Optional[SevHas
 def snp_update_section(desc: OvmfSevMetadataSectionDesc, gctx: GCTX, ovmf: OVMF,
                        sev_hashes: Optional[SevHashes], vmm_type: VMMType) -> None:
     if desc.section_type() == SectionType.SNP_SEC_MEM:
-        gctx.update_zero_pages(desc.gpa, desc.size)
+        if vmm_type == VMMType.gce:
+            gctx.update_unmeasured_pages(desc.gpa, desc.size)
+        else:
+            gctx.update_zero_pages(desc.gpa, desc.size)
     elif desc.section_type() == SectionType.SNP_SECRETS:
         gctx.update_secrets_page(desc.gpa)
     elif desc.section_type() == SectionType.CPUID:

--- a/sevsnpmeasure/vmm_types.py
+++ b/sevsnpmeasure/vmm_types.py
@@ -4,3 +4,4 @@ from enum import Enum
 class VMMType(Enum):
     QEMU = 1
     ec2 = 2
+    gce = 3

--- a/tests/test_guest.py
+++ b/tests/test_guest.py
@@ -128,6 +128,38 @@ class TestGuest(unittest.TestCase):
                 '7d3756157c805bf6adf617064c8552e8c1688fa1c8756f11'
                 'cbf56ba5d25c9270fb69c0505c1cbe1c5c66c0e34c6ed3be')
 
+    def test_snp_gce_default(self):
+        ld = guest.calc_launch_digest(
+                SevMode.SEV_SNP,
+                1,
+                None,
+                "tests/fixtures/ovmf_AmdSev_suffix.bin",
+                "/dev/null",
+                "/dev/null",
+                "",
+                0x1,
+                vmm_type=vmm_types.VMMType.gce)
+        self.assertEqual(
+                ld.hex(),
+                '5da7106cf14cf46b1725ebab123eb9e53bd46a1e9f400cd0'
+                'c08e7827b04b688ea8b4e403c8404efed4397ea5d5d0722e')
+
+    def test_snp_gce_with_multiple_vcpus_default(self):
+        ld = guest.calc_launch_digest(
+                SevMode.SEV_SNP,
+                4,
+                None,
+                "tests/fixtures/ovmf_AmdSev_suffix.bin",
+                "/dev/null",
+                "/dev/null",
+                "",
+                0x1,
+                vmm_type=vmm_types.VMMType.gce)
+        self.assertEqual(
+                ld.hex(),
+                '5c5debf100fc339f90276e761ee1f1658d08922c3b20e2a2'
+                'e6c7a6c3370b2452a15a00eae11886a93d6fd1e7ab81e29d')
+
     def test_snp_default(self):
         ld = guest.calc_launch_digest(
                 SevMode.SEV_SNP,


### PR DESCRIPTION
Google Compute Engine (GCE) made Confidential VMs with SEV-SNP support generally available in June 2024 [1]. This patch adds support for deriving measurements for SEV-SNP guests running on GCE.

GCE's measurement calculation differs from QEMU and EC2 implementations. The differences include:
- Some metadata pages are loaded as a different page type
- Initial CPU register state uses different values

(Specifics interpreted from [2])

This patch introduces a new VMM type: 'gce'.

[1] https://cloud.google.com/blog/products/identity-security/rsa-snp-vm-more-confidential
[2] https://github.com/google/gce-tcb-verifier