### PR TITLE
setup.cfg: Replace license classifier with license field

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -7,12 +7,12 @@ description = Calculate expected measurement of an AMD SEV/SEV-ES/SEV-SNP guest 
 long_description = file: README.md
 long_description_content_type = text/markdown
 url = https://github.com/virtee/sev-snp-measure
+license = Apache-2.0
 project_urls =
     Bug Tracker = https://github.com/virtee/sev-snp-measure/issues
 classifiers =
     Development Status :: 4 - Beta
     Intended Audience :: Developers
-    License :: OSI Approved :: Apache Software License
     Programming Language :: Python :: 3
     Operating System :: OS Independent
     Topic :: Security


### PR DESCRIPTION
License classifiers are deprecated; cause this warning when building with `make build_packages`:

```
SetuptoolsDeprecationWarning: License classifiers are deprecated.
!!

        ********************************************************************************
        Please consider removing the following classifiers in favor of a SPDX license expression:

        License :: OSI Approved :: Apache Software License

        See https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license for details.
        ********************************************************************************

!!
```
