### PR TITLE
Update the EC2 VMSA used to calculate the expected measurement

### DIFF
--- a/sevsnpmeasure/vmsa.py
+++ b/sevsnpmeasure/vmsa.py
@@ -159,7 +159,7 @@ class VMSA(object):
                 cs_flags = 0x9a
             ss_flags = 0x92
             tr_flags = 0x83
-            rdx = 0
+            rdx = 0x600
             mxcsr = 0
             fcw = 0
         elif vmm_type == VMMType.gce:

--- a/tests/test_guest.py
+++ b/tests/test_guest.py
@@ -109,8 +109,8 @@ class TestGuest(unittest.TestCase):
                 vmm_type=vmm_types.VMMType.ec2)
         self.assertEqual(
                 ld.hex(),
-                '6ae80856486b1396af8c82a40351d6ed76a20c785e9c7fa4'
-                'ffa27c22d5d6313b4b3b458cd3c9968e6f89fb5d8450d7a6')
+                '0ce9ccc06bab55eebe8abc234f3df6514883977a68a591b7'
+                '1052498ab52b2f1aa415db338033946ef93aa8278c0d67fb')
 
     def test_snp_ec2_feature_snp_only(self):
         ld = guest.calc_launch_digest(
@@ -125,8 +125,8 @@ class TestGuest(unittest.TestCase):
                 vmm_type=vmm_types.VMMType.ec2)
         self.assertEqual(
                 ld.hex(),
-                '7d3756157c805bf6adf617064c8552e8c1688fa1c8756f11'
-                'cbf56ba5d25c9270fb69c0505c1cbe1c5c66c0e34c6ed3be')
+                '0883bd0eeb716e65b7b977a321c278d1e51b33b5c655fab9'
+                '85443bbcc65c086b9c15e8a0bd8811050dec7e24964e5056')
 
     def test_snp_gce_default(self):
         ld = guest.calc_launch_digest(


### PR DESCRIPTION
This is a one line change to ensure that the VMSA is up-to-date so that measurements can be calculated correctly for SEV-SNP guests in EC2.

I have tested this with a `c6a.xlarge` EC2 instance which has a measurement of `b756dde72c548e42560ba6b43955b68c1239682104c78fa07989ed3d15478107cb0e0a2a9637604586b9615eb8da7617`.

Using the command below, the produced measurement is an exact match after applying this patch.

```
./sev-snp-measure.py --mode snp --vcpus 4 --vmm-type=ec2  --ovmf $AWS_OVMF_PATH
```

The `$AWS_OVMF_PATH` is the path to the `ovmf_img.fd`  file produced from [aws/uefi](https://github.com/aws/uefi/).
