### PR TITLE
Add EPYC-Turin to vcpu_types.py

### DIFF
--- a/sevsnpmeasure/vcpu_types.py
+++ b/sevsnpmeasure/vcpu_types.py
@@ -41,4 +41,5 @@ CPU_SIGS = {
     'EPYC-Milan-v2': cpu_sig(family=25, model=1, stepping=1),
     'EPYC-Genoa': cpu_sig(family=25, model=17, stepping=0),
     'EPYC-Genoa-v1': cpu_sig(family=25, model=17, stepping=0),
+    'EPYC-Turin': cpu_sig(family=26, model=0, stepping=0),
 }


### PR DESCRIPTION
The source of the CPU sig is https://gitlab.com/qemu-project/qemu/-/blob/master/target/i386/cpu.c#L7216