### PR TITLE
CI: Update the list of Python versions for testing

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
 
     steps:
     - uses: actions/checkout@v4

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,7 +20,7 @@ classifiers =
 
 [options]
 packages = sevsnpmeasure
-python_requires = >=3.7
+python_requires = >=3.10
 install_requires =
     cryptography>=39.0.1
 


### PR DESCRIPTION
Remove unsupported Python 3.8 and 3.9
Add 3.12, 3.13, 3.14.

Signed-off-by: Dov Murik <dov.murik@gmail.com>
