### PR TITLE
Allow 0 as a valid vcpu_sig value in CLI

### DIFF
--- a/sevsnpmeasure/cli.py
+++ b/sevsnpmeasure/cli.py
@@ -35,9 +35,9 @@ def print_measurement(ld: bytes, sev_mode: SevMode, output_format: str, verbose:
 def get_vcpu_sig(parser, args, vmm_type):
     if args.mode == 'sev':
         return 0
-    elif args.vcpu_family:
+    elif args.vcpu_family is not None:
         return vcpu_types.cpu_sig(args.vcpu_family, args.vcpu_model, args.vcpu_stepping)
-    elif args.vcpu_sig:
+    elif args.vcpu_sig is not None:
         return args.vcpu_sig
     elif args.vcpu_type:
         return vcpu_types.CPU_SIGS[args.vcpu_type]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,46 @@
+import unittest
+from argparse import Namespace
+from sevsnpmeasure.cli import get_vcpu_sig
+from sevsnpmeasure.vmm_types import VMMType
+from sevsnpmeasure.vcpu_types import CPU_SIGS, cpu_sig
+
+
+class TestCLI(unittest.TestCase):
+    def test_get_vcpu_sig_zero(self):
+        args = Namespace(mode="snp", vcpu_family=None, vcpu_sig=0, vcpu_type=None)
+        sig = get_vcpu_sig(None, args, VMMType.QEMU)
+        self.assertEqual(sig, 0)
+
+    def test_get_vcpu_sig_none_qemu_errors(self):
+        class MockParser:
+            def error(self, msg):
+                raise ValueError(msg)
+
+        parser = MockParser()
+        args = Namespace(mode="snp", vcpu_family=None, vcpu_sig=None, vcpu_type=None)
+        with self.assertRaises(ValueError):
+            get_vcpu_sig(parser, args, VMMType.QEMU)
+
+    def test_get_vcpu_sig_from_type(self):
+        args = Namespace(
+            mode="snp", vcpu_family=None, vcpu_sig=None, vcpu_type="EPYC-Milan"
+        )
+        sig = get_vcpu_sig(None, args, VMMType.QEMU)
+        self.assertEqual(sig, CPU_SIGS["EPYC-Milan"])
+
+    def test_get_vcpu_sig_from_family(self):
+        CPU_FAMILY = 25
+        CPU_MODEL = 1
+        CPU_STEPPING = 1
+
+        args = Namespace(
+            mode="snp",
+            vcpu_family=CPU_FAMILY,
+            vcpu_model=CPU_MODEL,
+            vcpu_stepping=CPU_STEPPING,
+            vcpu_sig=None,
+            vcpu_type=None,
+        )
+        expected = cpu_sig(CPU_FAMILY, CPU_MODEL, CPU_STEPPING)
+        sig = get_vcpu_sig(None, args, VMMType.QEMU)
+        self.assertEqual(sig, expected)


### PR DESCRIPTION
This PR fixes a bug where 0 was incorrectly rejected as a valid value for --vcpu-sig (and related flags like --vcpu-family) due to falsy checks in the argument processing logic.

Motivation:
In many CI/CD workflows, guest measurements are calculated immediately after a build, often before the specific target CPU model for the deployment is known. Additionally, when using QEMU
  with -cpu host, it is common to use a signature of 0 to maintain a stable or generic measurement baseline.

  Allowing 0 as a valid signature also aligns this tool with other key projects in the AMD SEV ecosystem, such as the Rust sev crate
  (https://github.com/virtee/sev/blob/76535be354648a3e4adf00631fdf4941ab51fb88/src/measurement/vcpu_types.rs#L54), which explicitly supports zeroed signatures.

Thank you.